### PR TITLE
Fixed validation of query params for `GET /stations`, error logging

### DIFF
--- a/models/stations.js
+++ b/models/stations.js
@@ -76,8 +76,8 @@ class Stations {
         }
 
         if (options.filter && options.filter.has('geolocation')) {
-          const [longitude, latitude] = options.filter.get('geolocation').split(',');
-          query = query.getNearest(database.point(+longitude, +latitude), { index: 'geolocation' });
+          const [latitude, longitude] = options.filter.get('geolocation');
+          query = query.getNearest(database.point(longitude, latitude), { index: 'geolocation' });
         }
 
         if (options.sort) {
@@ -100,7 +100,7 @@ class Stations {
       .catch(err => {
         const error = new Error('Failed to execute `Stations::fetch`');
 
-        logger.error(error.message);
+        logger.error(error);
         return Promise.reject(error);
       });
   }

--- a/routes.js
+++ b/routes.js
@@ -21,12 +21,15 @@ module.exports = [
             call: Joi.string(),
             format: Joi.string(),
             frequency: Joi.number(),
+            geolocation: Joi.array().items(Joi.number()),
             market_city: Joi.string(),
             market_state: Joi.string(),
             name: Joi.string(),
             tagline: Joi.string(),
             title: Joi.string()
-          })
+          }),
+          sort: Joi.string(),
+          page: Joi.string()
         }
       }
     },


### PR DESCRIPTION
- The `geolocation`, `sort`, and `page` query string params were
disallowed.
- Fixed the order of lat/lng input
- Changed to logging the full error object